### PR TITLE
use sed instead of gsed to improve compatibility / redirect errors to…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ compile:
 
 tests:
 	cd test
-	for c in $$(ls *Test.class | gsed s/.class//); do
+	for c in $$(ls *Test.class | sed s/.class//); do
 		java -enableassertions -classpath .:../src $${c}
 	done

--- a/src/Trim.java
+++ b/src/Trim.java
@@ -1,17 +1,21 @@
 class Trim {
     private final String text;
+
     public Trim(String t) {
         this.text = t;
     }
+
     public String take() {
         int start = 0;
         while (this.text.charAt(start) == ' ') {
-            start += 1;
+            start++;
         }
+
         int end = this.text.length() - 1;
         while (this.text.charAt(end) == ' ') {
-            end -= 1;
+            end--;
         }
+
         return this.text.substring(start, end + 1);
     }
 }

--- a/src/Upper.java
+++ b/src/Upper.java
@@ -1,9 +1,10 @@
 class Upper {
     public static String up(String text) {
         String r = "";
-        for (int p = 0; p < text.length(); p = p + 1) {
-            r = r + Character.toUpperCase(text.charAt(p));
+        for (int p = 0; p < text.length(); p++) {
+            r += Character.toUpperCase(text.charAt(p));
         }
+
         return r;
     }
 }

--- a/test/Assert.java
+++ b/test/Assert.java
@@ -1,7 +1,7 @@
 class Assert {
     public static <T> void equals(T left, T right) {
         if (!left.equals(right)) {
-            System.out.printf("%s not equal to %s\n", left, right);
+            System.err.printf("%s not equal to %s\n", left, right);
             throw new AssertionError();
         }
     }


### PR DESCRIPTION
Using "sed" instead of the "gsed" command to improve compatibility.
- Redirect errors to stderr (System.err) instead of stdout (System.out)
- Using ++ instead of += for some sentences.