### PR TITLE
Fix trim for empty strings and non-space characters

### DIFF
--- a/src/Trim.java
+++ b/src/Trim.java
@@ -4,14 +4,6 @@ class Trim {
         this.text = t;
     }
     public String take() {
-        int start = 0;
-        while (this.text.charAt(start) == ' ') {
-            start += 1;
-        }
-        int end = this.text.length() - 1;
-        while (this.text.charAt(end) == ' ') {
-            end -= 1;
-        }
-        return this.text.substring(start, end + 1);
+        return text.trim();
     }
 }

--- a/test/TrimTest.java
+++ b/test/TrimTest.java
@@ -2,5 +2,8 @@ class TrimTest {
     public static void main(String... args) {
         Assert.equals(new Trim("  hello   ").take(), "hello");
         Assert.equals(new Trim("  hello, world!   ").take(), "hello, world!");
+        Assert.equals(new Trim("     ").take(), "");
+        Assert.equals(new Trim("").take(), "");
+        Assert.equals(new Trim("\t\t").take(), "");
     }
 }


### PR DESCRIPTION
```java
Assert.equals(new Trim("     ").take(), "");
Assert.equals(new Trim("").take(), "");
Assert.equals(new Trim("\t\t").take(), "");
```

failed for `Trim` class. This PR fixes the issue.