### PR TITLE
fix Reverse::reverse for Unicode surrogates

### DIFF
--- a/src/Reverse.java
+++ b/src/Reverse.java
@@ -1,8 +1,20 @@
+import java.util.ArrayList;
+
 class Reverse {
     public static String reverse(String text) {
         StringBuilder r = new StringBuilder();
-        for (int p = text.length(); p > 0; p = p - 1) {
-            r.append(text.charAt(p - 1));
+
+        ArrayList<Integer> list = new ArrayList<>();
+        // credits to https://stackoverflow.com/a/1527891/2204326 as per CC BY-SA 3.0
+        final int length = text.length();
+        for (int offset = 0; offset < length; /*noop*/) {
+            final int codepoint = text.codePointAt(offset);
+            list.add(codepoint);
+            offset += Character.charCount(codepoint);
+        }
+        for (int i = list.size(); i > 0; i--) {
+            final int codepoint = list.get(i - 1);
+            r.appendCodePoint(codepoint);
         }
         return r.toString();
     }

--- a/test/ReverseTest.java
+++ b/test/ReverseTest.java
@@ -3,5 +3,9 @@ class ReverseTest {
         Assert.equals(Reverse.reverse("123"), "321");
         Assert.equals(Reverse.reverse("hello"), "olleh");
         Assert.equals(Reverse.reverse("привет"), "тевирп");
+        // chinese "hello"
+        Assert.equals(Reverse.reverse("你好"), "好你");
+        // slightly smiling face emoji
+        Assert.equals(Reverse.reverse("🙂"), "🙂");
     }
 }


### PR DESCRIPTION
This is suboptimal solution, but it seems that iterating codepoints
right-to-left is hard. We still can do optimizations if proves
necessary.

Fixes #11